### PR TITLE
Day-Three Patch

### DIFF
--- a/boards/dev/raspberrypi/pico/config.h
+++ b/boards/dev/raspberrypi/pico/config.h
@@ -1,0 +1,101 @@
+#pragma once
+// The Raspberry Pi Pico is a general development board.
+// The following describes the available capabilities of the Pico development board in a way that makes it easy to use in controller configurations.
+// This description is set up in a way to align Pico "GP" numbers with channels numbers.
+// Certain channels will not be available because of this alignment. These will be marked with "PIN_NC"
+
+#define BUTTON_DRIVER direct
+#define BUTTONS_AVAILABLE 29
+#define BUTTON_PINS \
+   0,  1,  2,  3,  4,  5,  6,  7, \
+   8,  9, 10, 11, 12, 13, 14, 15, \
+  16, 17, 18, 19, 20, 21, 22, \
+  PIN_NC, PIN_NC, PIN_NC, \
+  26, 27, 28
+
+// The channel number of the encoder indicates the Pico pin number + the pin after
+// e.g. Encoder channel 5 uses Pico pins 5 and 6
+// Channels 22-25 and 28 are not valid since they contain a non-valid pin number.
+#define ENCODER_DRIVER direct
+#define ENCODERS_AVAILABLE 29
+#define ENCODER_PINS \
+  [ 0] = {0,1}, \
+  [ 1] = {1,2}, \
+  [ 2] = {2,3}, \
+  [ 3] = {3,4}, \
+  [ 4] = {4,5}, \
+  [ 5] = {5,6}, \
+  [ 6] = {6,7}, \
+  [ 7] = {7,8}, \
+  [ 8] = {8,9}, \
+  [ 9] = {9,10}, \
+  [10] = {10,11}, \
+  [11] = {11,12}, \
+  [12] = {12,13}, \
+  [13] = {13,14}, \
+  [14] = {14,15}, \
+  [15] = {15,16}, \
+  [16] = {16,17}, \
+  [17] = {17,18}, \
+  [18] = {18,19}, \
+  [19] = {19,20}, \
+  [20] = {20,21}, \
+  [21] = {21,22}, \
+  [22] = {PIN_NC,PIN_NC}, \
+  [23] = {PIN_NC,PIN_NC}, \
+  [24] = {PIN_NC,PIN_NC}, \
+  [25] = {PIN_NC,PIN_NC}, \
+  [26] = {26,27}, \
+  [27] = {27,28}, \
+  [28] = {PIN_NC,PIN_NC}
+
+// The Pico only has 3 analog pins: 26, 27, and 28.
+// While "29" channels are available, to keep the pin mapping true, only 26-28 are usable.
+#define ANALOG_DRIVER direct
+#define ANALOG_CHANNELS_AVAILABLE 29
+#define ANALOG_PINS \
+  PIN_NC, PIN_NC, PIN_NC, PIN_NC, PIN_NC, PIN_NC, PIN_NC, PIN_NC, \
+  PIN_NC, PIN_NC, PIN_NC, PIN_NC, PIN_NC, PIN_NC, PIN_NC, PIN_NC, \
+  PIN_NC, PIN_NC, PIN_NC, PIN_NC, PIN_NC, PIN_NC, PIN_NC, PIN_NC, \
+  PIN_NC, PIN_NC, 26, 27, 28
+
+#define LIGHT_DRIVER direct
+#define LIGHTS_AVAILABLE 29
+#define LIGHT_PINS \
+   0,  1,  2,  3,  4,  5,  6,  7, \
+   8,  9, 10, 11, 12, 13, 14, 15, \
+  16, 17, 18, 19, 20, 21, 22, \
+  PIN_NC, PIN_NC, PIN_NC, \
+  26, 27, 28
+
+// The PIO RGB driver is enabled by default.
+// This will be enabled on one of the two PIOs available, pio0.
+// Up to four RGB channels are available on any four pins.
+#define RGB_DRIVER pio
+#define RGB_CHANNELS_AVAILABLE 29
+#define RGB_PIO pio0
+#define RGB_PINS \
+   0,  1,  2,  3,  4,  5,  6,  7, \
+   8,  9, 10, 11, 12, 13, 14, 15, \
+  16, 17, 18, 19, 20, 21, 22, \
+  PIN_NC, PIN_NC, PIN_NC, \
+  26, 27, 28
+
+// The PIO PSX driver is opt-in, and requires PSX_ACTIVE to be defined to enable it.
+// This uses the remaining PIO, pio1.
+#define PSX_DRIVER pio
+#define PSX_PIO pio1
+// The PIO driver requires no additional parts and has a couple caveats:
+// * Three of the pins, DAT (MISO), ATT (SS), and ACK, can be any pin.
+// * CMD will be the pin specified on PSX_CMD_CLK_PINBASE.
+// * CLK will be the next pin after CLK (PSX_CMD_CLK_PINBASE + 1).
+// If you wish to enable PSX support, copy and uncomment the following:
+// #define PSX_ACTIVE
+// #define PSX_CMD_CLK_PINBASE  4 // for CMD, pin 5 will be CLK
+// #define PSX_ATT_PIN          3
+// #define PSX_DAT_PIN          2
+// #define PSX_ACK_PIN          1
+
+/*** Chain Inclusion ***/
+// This is what tells the compiler to include the controller configuration.
+#include_next "config.h"

--- a/boards/dev/raspberrypi/pico/rules.mk
+++ b/boards/dev/raspberrypi/pico/rules.mk
@@ -1,0 +1,1 @@
+TARGET_ARCH = pico

--- a/common/rgb.h
+++ b/common/rgb.h
@@ -7,6 +7,7 @@
 #include "rgb/defs.h"
 #include "color/defs.h"
 #include "impl/rgb.h"
+#include "utils.h"
 
 /*** Declarations ***/
 // Storage for RGB LEDs
@@ -22,6 +23,7 @@ static inline void RGB_Init(void) {
   _impl_rgb_init();
 #endif
 }
+
 // Determines if the next frame's values should be calculated
 static inline bool RGB_ReadyToCalculate(void) {
   bool tick = _rgb_status.tick;
@@ -29,15 +31,18 @@ static inline bool RGB_ReadyToCalculate(void) {
 
   return tick;
 }
+
 // Determines if the next frame is ready to be drawn
 static inline bool RGB_ReadyToDraw(void) {
   return _impl_rgb_ready() && _rgb_status.vsync;
 }
+
 // Renders RGB
 static inline void RGB_Render(void) {
   _rgb_status.vsync = false;
   _impl_rgb_render();
 }
+
 // Regularly-schedule RGB status update task
 static inline void RGB_UpdateStatus(void) {
   static const uint16_t wait = (TASK_TIMER_FREQUENCY / RGB_FRAMERATE_TARGET);
@@ -55,6 +60,7 @@ static inline void RGB_UpdateStatus(void) {
   if (_impl_rgb_ready())
     _rgb_status.vsync  = true;
 }
+
 // Returns the offset in the RGB buffer for a given channel
 static inline const uint16_t _rgb_channelOffset(const uint8_t channel) {
   const uint8_t per_channel[RGB_CHANNELS_ACTIVE] = { RGB_LEDS_PER_CHANNEL };
@@ -66,12 +72,14 @@ static inline const uint16_t _rgb_channelOffset(const uint8_t channel) {
 
   return offset;
 }
+
 // Returns the count of LEDs for a given channel
 static inline const uint8_t _rgb_channelCount(const uint8_t channel) {
   const uint8_t per_channel[RGB_CHANNELS_ACTIVE] = { RGB_LEDS_PER_CHANNEL };
   if (channel >= RGB_CHANNELS_ACTIVE) return 0;
   return per_channel[channel];
 }
+
 // Sets an RGB LED on a given channel/position to a specific color
 static inline void RGB_Set(const uint8_t channel, const uint8_t index, RGB_Color_t color) {
   if (index >= _rgb_channelCount(channel)) return;
@@ -95,26 +103,91 @@ static inline RGB_Color_t RGB_Get(const uint8_t channel, const uint8_t index) {
 
   return color;
 }
+
 // Sets a range of LEDs on a given channel to a specific color
 static inline void RGB_SetRange(const uint8_t channel, const uint8_t start, const uint8_t count, RGB_Color_t color) {
   const uint8_t  chanSize = _rgb_channelCount(channel);
   const uint16_t offset   = _rgb_channelOffset(channel);
 
-  for (uint8_t i = 0; i < count; i++) {
-    if ((start + i) >= chanSize) return;
+  const uint8_t c = (count < chanSize ? count : chanSize);
+
+  for (uint8_t i = 0; i < c; i++) {
     _rgb[offset + start + i].r = color.r,
     _rgb[offset + start + i].g = color.g,
     _rgb[offset + start + i].b = color.b;
   }
 }
-// Clears all LEDs on a given channel
-static inline void RGB_Clear(const uint8_t channel) {
-  const uint16_t count  = _rgb_channelCount(channel);
-  const uint16_t offset = _rgb_channelOffset(channel);
 
-  if (count)
-    memset(&_rgb[offset], 0, count * 3);
+// Clears all LEDs in a given range on a given channel
+static inline void RGB_ClearRange(const uint8_t channel, const uint8_t start, const uint8_t count) {
+  const uint16_t chanSize = _rgb_channelCount(channel);
+  const uint16_t offset   = _rgb_channelOffset(channel);
+
+  const uint8_t c = (count < chanSize ? count : chanSize);
+  if (!c) return;
+  memset(&_rgb[offset + start], 0, c * 3);
 }
+
+// Clears all LEDs on a given channel
+static inline void RGB_ClearAll(const uint8_t channel) {
+  const uint16_t chanSize = _rgb_channelCount(channel);
+
+  if (chanSize)
+    RGB_ClearRange(channel, 0, chanSize);
+}
+
+// Fades all LEDs in a given range on a given channel by a factor
+static inline void RGB_FadeRange(const uint8_t channel, const uint8_t start, const uint8_t count, const uint8_t factor) {
+  const uint16_t chanSize = _rgb_channelCount(channel);
+  const uint16_t offset   = _rgb_channelOffset(channel);
+
+  const uint8_t c = (count < chanSize ? count : chanSize);
+  for (uint8_t i = 0; i < c; i++) {
+    if ((start + i) >= c) return;
+    _rgb[offset + start + i].r = (
+      (_rgb[offset + start + i].r << factor) - (_rgb[offset + start + i].r)) >> factor;
+    _rgb[offset + start + i].g = (
+      (_rgb[offset + start + i].g << factor) - (_rgb[offset + start + i].g)) >> factor;
+    _rgb[offset + start + i].b = (
+      (_rgb[offset + start + i].b << factor) - (_rgb[offset + start + i].b)) >> factor;
+  }
+}
+
+// Fades all LEDs in a given range on a given channel by a random factor 1-8
+static inline void RGB_FadeRangeRandom(const uint8_t channel, const uint8_t start, const uint8_t count) {
+  const uint16_t chanSize = _rgb_channelCount(channel);
+  const uint16_t offset   = _rgb_channelOffset(channel);
+
+  const uint8_t c = (count < chanSize ? count : chanSize);
+  for (uint8_t i = 0; i < c; i++) {
+    if ((start + i) >= c) return;
+    const uint8_t factor = (Utils_Random() & 0x07) + 1;
+
+    _rgb[offset + start + i].r = (
+      (_rgb[offset + start + i].r << factor) - (_rgb[offset + start + i].r)) >> factor;
+    _rgb[offset + start + i].g = (
+      (_rgb[offset + start + i].g << factor) - (_rgb[offset + start + i].g)) >> factor;
+    _rgb[offset + start + i].b = (
+      (_rgb[offset + start + i].b << factor) - (_rgb[offset + start + i].b)) >> factor;
+  }
+}
+
+// Fades all LEDs on a given channel by a factor
+static inline void RGB_FadeAll(const uint8_t channel, const uint8_t factor) {
+  const uint16_t chanSize = _rgb_channelCount(channel);
+
+  if (chanSize)
+    RGB_FadeRange(channel, 0, chanSize, factor);
+}
+
+// Fades all LEDs on a given channel by a random factor
+static inline void RGB_FadeAllRandom(const uint8_t channel) {
+  const uint16_t chanSize = _rgb_channelCount(channel);
+
+  if (chanSize)
+    RGB_FadeRangeRandom(channel, 0, chanSize);
+}
+
 #else
 static inline void RGB_Init(void) { }
 static inline bool RGB_ReadyToCalculate(void) { return false; }

--- a/common/utils.c
+++ b/common/utils.c
@@ -1,0 +1,12 @@
+#include "utils.h"
+
+// Returns a random 16-bit number
+uint16_t Utils_Random(void) {
+  static uint16_t rand;
+  if (!rand) rand = 0x5a5a;
+
+  rand ^= rand >> 7;
+  rand ^= rand << 9;
+  rand ^= rand >> 13;
+  return rand;
+}

--- a/common/utils.h
+++ b/common/utils.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <stdbool.h>
+#include <stdint.h>
 
 /*** Defines ***/
 #define Button_HeldExclusively(button_mask) \
@@ -35,10 +37,12 @@
 
 
 /*** Functions ***/
-// Given a current and max value, map the position in the range 0-255.
+// Given a current and max value, map the current value to the range 0-255 based on the max.
 static inline uint8_t Utils_RangeToU8(uint16_t curr, const uint16_t max) {
   const uint16_t reciprocal = (0xFFFF / max);
         uint16_t result     = curr * reciprocal;
 
   return result >> 8;
 }
+
+uint16_t Utils_Random(void);

--- a/configs/examples/raspberrypi/pico/iidx/default/config.h
+++ b/configs/examples/raspberrypi/pico/iidx/default/config.h
@@ -1,0 +1,7 @@
+#pragma once
+// The Raspberry Pi Pico is a general development board.
+// The following provides a sample user configuration for the Pico dev board in a IIDX controller.
+
+/*** Additional Includes ***/
+// We'll include some friendly USB labels in a separate file.
+#include "labels.h"

--- a/configs/examples/raspberrypi/pico/iidx/default/labels.h
+++ b/configs/examples/raspberrypi/pico/iidx/default/labels.h
@@ -1,0 +1,35 @@
+#pragma once
+// The following provides customizable USB strings to USBemani.
+// This allows for certain software to describe the functions in a more friendly manner.
+// Not every piece of software supports every type of string.
+
+/*** Buttons ***/
+#define USB_STRING_BUTTON_1   "Key 1"
+#define USB_STRING_BUTTON_2   "Key 2"
+#define USB_STRING_BUTTON_3   "Key 3"
+#define USB_STRING_BUTTON_4   "Key 4"
+#define USB_STRING_BUTTON_5   "Key 5"
+#define USB_STRING_BUTTON_6   "Key 6"
+#define USB_STRING_BUTTON_7   "Key 7"
+#define USB_STRING_BUTTON_8   "E1"
+#define USB_STRING_BUTTON_9   "E2"
+#define USB_STRING_BUTTON_10  "E3"
+#define USB_STRING_BUTTON_11  "E4"
+
+/*** Encoders ***/
+#define USB_STRING_ENCODER_1  "Turntable"
+
+/*** RGB ***/
+// Our example controller has 12 RGB channels: 7 keys, the 4 E- buttons, and the turntable (in that order)
+#define USB_STRING_RGB_1      "Key 1"
+#define USB_STRING_RGB_2      "Key 2"
+#define USB_STRING_RGB_3      "Key 3"
+#define USB_STRING_RGB_4      "Key 4"
+#define USB_STRING_RGB_5      "Key 5"
+#define USB_STRING_RGB_6      "Key 6"
+#define USB_STRING_RGB_7      "Key 7"
+#define USB_STRING_RGB_8      "E1"
+#define USB_STRING_RGB_9      "E2"
+#define USB_STRING_RGB_10     "E3"
+#define USB_STRING_RGB_11     "E4"
+#define USB_STRING_RGB_12     "Turntable Ring"

--- a/configs/examples/raspberrypi/pico/iidx/default/rules.mk
+++ b/configs/examples/raspberrypi/pico/iidx/default/rules.mk
@@ -1,0 +1,1 @@
+# This file is empty, but must be present

--- a/configs/examples/raspberrypi/pico/iidx/default/user.c
+++ b/configs/examples/raspberrypi/pico/iidx/default/user.c
@@ -1,4 +1,4 @@
-// The Arduino Pro Micro is a general development board.
+// The Raspberry Pi Pico is a general development board.
 // The following provides a sample of user-customized code to USBemani.
 
 // All code should start by including the main "usbemani.h" file. This provides access to system functions

--- a/configs/lain/mini-4/rev1/default/user.c
+++ b/configs/lain/mini-4/rev1/default/user.c
@@ -17,7 +17,7 @@ void CALLBACK_OnRGBDrawFallback() {
   const RGB_Color_t red   = {.r=128};
 
   // Clear the channel
-  RGB_Clear(0);
+  RGB_ClearAll(0);
   // Draw the keys
   for (uint8_t i = 0; i < 7; i++) {
     if (Button_Get(i))
@@ -36,7 +36,7 @@ void CALLBACK_OnRGBDrawFallback() {
 }
 
 void CALLBACK_OnRGBDrawUSB(USB_OutputReport_t *output) {
-  RGB_Clear(0);
+  RGB_ClearAll(0);
   // Draw the 7 keys
   for (int i = 0; i < 7; i++) {
     RGB_SetRange(0, (i * RGB_LEDS_PER_KEY), RGB_LEDS_PER_KEY, output->rgb[i]);

--- a/configs/lain/mini-4/rev2/default/user.c
+++ b/configs/lain/mini-4/rev2/default/user.c
@@ -16,12 +16,12 @@ void CALLBACK_OnRGBDrawFallback() {
   const RGB_Color_t white = {.r=128,.g=128,.b=128};
   const RGB_Color_t red   = {.r=128};
 
-  RGB_FadeAll(0, 6);
-
+  // Clear the channel
+  RGB_ClearAll(0);
   // Draw the keys
   for (uint8_t i = 0; i < 7; i++) {
     if (Button_Get(i))
-      RGB_SetRange(0, (i * RGB_LEDS_PER_KEY), 4, (i % 2 ? red : white));
+      RGB_SetRange(0, (i * RGB_LEDS_PER_KEY), RGB_LEDS_PER_KEY, (i % 2 ? red : white));
   }
   // Draw E1-E4, also white
   for (uint8_t i = 0; i < 4; i++) {

--- a/configs/lain/mini-4/rev2/default/user.c
+++ b/configs/lain/mini-4/rev2/default/user.c
@@ -16,12 +16,12 @@ void CALLBACK_OnRGBDrawFallback() {
   const RGB_Color_t white = {.r=128,.g=128,.b=128};
   const RGB_Color_t red   = {.r=128};
 
-  // Clear the channel
-  RGB_Clear(0);
+  RGB_FadeAll(0, 6);
+
   // Draw the keys
   for (uint8_t i = 0; i < 7; i++) {
     if (Button_Get(i))
-      RGB_SetRange(0, (i * RGB_LEDS_PER_KEY), RGB_LEDS_PER_KEY, (i % 2 ? red : white));
+      RGB_SetRange(0, (i * RGB_LEDS_PER_KEY), 4, (i % 2 ? red : white));
   }
   // Draw E1-E4, also white
   for (uint8_t i = 0; i < 4; i++) {
@@ -36,7 +36,7 @@ void CALLBACK_OnRGBDrawFallback() {
 }
 
 void CALLBACK_OnRGBDrawUSB(USB_OutputReport_t *output) {
-  RGB_Clear(0);
+  RGB_ClearAll(0);
   // Draw the 7 keys
   for (int i = 0; i < 7; i++) {
     RGB_SetRange(0, (i * RGB_LEDS_PER_KEY), RGB_LEDS_PER_KEY, output->rgb[i]);

--- a/controllers/examples/arduino/pro-micro/iidx/labels.h
+++ b/controllers/examples/arduino/pro-micro/iidx/labels.h
@@ -1,1 +1,0 @@
-#pragma once

--- a/controllers/examples/raspberrypi/pico/iidx/config.h
+++ b/controllers/examples/raspberrypi/pico/iidx/config.h
@@ -1,0 +1,110 @@
+#pragma once
+// The Raspberry Pi Pico is a general development board.
+// The following provides a sample controller configuration for the Pico dev board in a IIDX controller.
+
+/*** Controller Type ***/
+// Our example is a IIDX controller. Including this line tells USBemani how to setup certain properties to best support IIDX.
+#define CONTROLLER_TYPE iidx
+
+/*** Buttons ***/
+// The number of active buttons to use.
+// For our example (a IIDX controller), we'll use 11 buttons.
+#define BUTTONS_ACTIVE 11
+// The channels in use.
+// For our example, we'll use pins 0-6 as our keys, and pins 7-10 for our E1-E4 buttons.
+// USBemani will automatically map these in the order provided, so pin 0 becomes our USB "Button 1", and pin 10 becomes "Button 11".
+#define BUTTON_CHANNELS 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+
+/*** Encoders ***/
+// If needed, the direction of all encoders can be reversed. We won't do this for our example, but it can be enabled with the following:
+// #define ENCODER_CHANNELS_REVERSED
+// The number of active encoders in use.
+#define ENCODERS_ACTIVE         1
+// The encoder channel we wish to use. Encoders use two pins per encoder.
+// Our board provides encoder channels using a "base pin" number for the first channel, with the next pin after for the second channel.
+// For our example, we'll use pin 14 as the base pin, which will use pins 14 and 15
+#define ENCODER_CHANNELS        14
+// The PPR of the encoders in use.
+// For optical tooth wheels, count the number of teeth on the wheel.
+// For pre-packaged encoders, use the PPR as stated on the encoder or in the datasheet.
+// USBemani will use this information to automatically scale the encoder to meet what the game expects for a full rotation of the encoder.
+// Our example will use a generic 360PPR encoder.
+#define ENCODER_PPR             360
+// The polling frequency for encoders, in hertz. A higher number means more frequent polling.
+// Our example uses what is considered a "high PPR" encoder. These encoders require more frequent polling to avoid error.
+// For our example controller, we'll poll our encoder at 32kHz.
+#define ENCODER_FREQUENCY       32000
+// The number of polling samples before an encoder input is considered valid.
+// A higher number (up to 255) can better correct for error, at the expense of a little bit of input lag.
+// A lower number is more responsive, but can be prone to error depending on the encoder in use.
+// For our example, we'll use the highest value, 255.
+// This will result in 255/32000 seconds of input lag at the latest (~8ms).
+#define ENCODER_SAMPLES_UNTIL_VALID     255
+// The number of "steps' before triggering a directional input.
+// For use on the PSX, PS2, or software like LR2, this defines how "far" the encoder has to rotate before triggering a direction.
+// This number is expressed in "quarter steps", which is our encoder PPR * 4 (in our example, we have 1440 quarter steps per rotation).
+// For our example, we'll trigger a directional input after 20 successive quarter steps in either direction. This means a 1/72 rotation will trigger a directional pulse.
+#define ENCODER_DIRECTION_THRESHOLD     20
+// How long a direction should hold, in milliseconds, before timing out.
+#define ENCODER_DIRECTION_HOLD_TIMEOUT  200
+
+/*** RGB ***/
+// How many RGB channels are active
+#define RGB_CHANNELS_ACTIVE     1
+// Which RGB channel to use
+#define RGB_CHANNELS            16
+// Which RGB LEDs are in use
+// For this example, we'll use WS2812 LEDs (e.g. NeoPixels)
+#define RGB_LED_TYPE            WS2812
+// How fast we should draw our RGB LEDs (our target framerate)
+// USBemani provides two parts to an RGB LED draw:
+// * An "effect update", which updates at our target framerate
+// * A "draw", which attempts to occur at our target framerate
+// Note that while a draw may can miss its window depending on the number of LEDs, the effect update will still occur at the framerate.
+// For our example, we'll target 120FPS
+#define RGB_FRAMERATE_TARGET    120
+// How many RGB LEDs per channel
+// Since our board only has one channel, we only need to provide one number
+// For our example, we'll say we have a single RGB LED per key/button, and a ring of 24 LEDs for the turntable
+// Custom user definitions can be added here for use in our code.
+#define RGB_LEDS_PER_TURNTABLE  24
+#define RGB_LEDS_PER_KEY        1
+// We can use these numbers to calculate our final number of RGB LEDs per channel
+// For our example, our buttons will be wired up first, in order, followed by our turntable:
+// Button 1 -> 2 -> 3 -> ... -> 9 -> 10 -> 11 -> Turntable
+#define RGB_LEDS_PER_CHANNEL    (BUTTONS_ACTIVE * RGB_LEDS_PER_KEY) + (RGB_LEDS_PER_TURNTABLE)
+
+/*** PSX ***/
+// Because the Pi Pico has enough pins available, our example will include PSX support.
+#define PSX_ACTIVE
+// As noted in the board's config files, there are a couple caveats:
+// * Three of the pins, DAT (MISO), ATT (SS), and ACK, can be any pin.
+// * CMD will be the pin specified on PSX_CMD_CLK_PINBASE.
+// * CLK will be the next pin after CLK (PSX_CMD_CLK_PINBASE + 1).
+// We'll use the following pins:
+#define PSX_CMD_CLK_PINBASE  18 // for CMD, pin 19 will be CLK
+#define PSX_ATT_PIN          20
+#define PSX_DAT_PIN          21
+#define PSX_ACK_PIN          22
+
+/*** USB ***/
+// The number of buttons to expose (11 buttons, plus 2 virtual for LR2)
+#define USB_BUTTONS_ACTIVE      13
+// The number of axes to expose for encoders
+#define USB_ENCODER_AXES_ACTIVE 1
+// Which USB axes to expose for encoders
+#define USB_ENCODERS_AXES       USB_Axis_X
+// The number of axes to expose for general purpose
+// IIDX doesn't use this, but it's provided to correct issues with certain test utilities
+#define USB_GENERAL_AXES_ACTIVE 1
+#define USB_GENERAL_AXES        USB_Axis_Y
+// The number of traditional light channels to expose
+// This example doesn't use traditional lights, but they can be enabled with the following:
+// #define USB_LIGHTS_ACTIVE    12
+// The number of RGB channels to expose
+// For this example, we'll expose 7 keys, 4 buttons, and the turntable, for a total of 12.
+#define USB_RGB_ACTIVE          12
+
+/*** Chain Inclusion ***/
+// This is what tells the compiler to include the user configuration.
+#include_next "config.h"

--- a/controllers/examples/raspberrypi/pico/iidx/rules.mk
+++ b/controllers/examples/raspberrypi/pico/iidx/rules.mk
@@ -1,0 +1,2 @@
+# This file defines which board we will be using
+TARGET_BOARD = dev/raspberrypi/pico


### PR DESCRIPTION
The following PR adds additional components:

**Additions**
- New board, controller, and configs for an example Raspberry Pi Pico devboard
- New target: `examples/raspberrypi/pico/iidx` implements a sample IIDX controller on the Pi Pico
- `rgb`: Rename `RGB_Clear` to `RGB_ClearAll`
- `rgb`: New function calls to clear and fade all or certain sections of LEDs
- `utils`: New PRNG random number generator