### PR TITLE
Fix post-build file move on Windows

### DIFF
--- a/arch/pico/CMakeLists.txt
+++ b/arch/pico/CMakeLists.txt
@@ -79,6 +79,12 @@ target_link_libraries(${TARGET_NAME}
 pico_add_extra_outputs(${TARGET_NAME})
 
 # Relocate built files to the /build folder
-add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
-  COMMAND mv ${TARGET_NAME}.* ${ROOT_DIR}/build/
-)
+if (CMAKE_HOST_WIN32)
+  add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+    COMMAND move ${TARGET_NAME}.* ${ROOT_DIR}/build/ > NUL
+  )
+else()
+  add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+    COMMAND mv ${TARGET_NAME}.* ${ROOT_DIR}/build/
+  )
+endif()


### PR DESCRIPTION
This is the only issue I encountered when building USBemani for my controller on Windows.

```
[7/7] Linking CXX executable community_aixxe_mini-4-optical.elf
FAILED: community_aixxe_mini-4-optical.elf 
cmd.exe /C "[...] && cd /D D:\usbemani\obj\community_aixxe_mini-4-optical && mv community_aixxe_mini-4-optical.* D:\usbemani/build/""
'mv' is not recognized as an internal or external command,
operable program or batch file.
ninja: build stopped: subcommand failed.
```

This change uses the `move` command when the host system is Windows.

Unlike `mv`, it will print paths for each moved file by default:
```
[7/7] Linking CXX executable community_aixxe_mini-4-optical.elf
D:\usbemani\obj\community_aixxe_mini-4-optical\community_aixxe_mini-4-optical.bin
D:\usbemani\obj\community_aixxe_mini-4-optical\community_aixxe_mini-4-optical.dis
D:\usbemani\obj\community_aixxe_mini-4-optical\community_aixxe_mini-4-optical.elf
D:\usbemani\obj\community_aixxe_mini-4-optical\community_aixxe_mini-4-optical.elf.map
D:\usbemani\obj\community_aixxe_mini-4-optical\community_aixxe_mini-4-optical.hex
D:\usbemani\obj\community_aixxe_mini-4-optical\community_aixxe_mini-4-optical.uf2
        6 file(s) moved.

Build finished
```
The `> NUL` at the end of the command supresses this, so it should be consistent with the behaviour on Linux/macOS.
```
[7/7] Linking CXX executable community_aixxe_mini-4-optical.elf

Build finished
```