### PR TITLE
The PS2 Update

### DIFF
--- a/arch/pico/impl/psx/pio.c
+++ b/arch/pico/impl/psx/pio.c
@@ -15,6 +15,7 @@ int64_t _impl_psx_releaseAck(alarm_id_t id, void *user_data) {
   Pin_OutputLow(PSX_ACK_PIN);
   asm volatile("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\n");
   Pin_Input(PSX_ACK_PIN);
+
   return 0;
 }
 
@@ -49,7 +50,11 @@ void _impl_psx_handle(void) {
   // Clear both FIFOs and interrupts
   // Repopulate TX (since we only need to push 8 bits at a time)
   pio_interrupt_clear(PSX_PIO, 0);
-  irq_clear(PIO1_IRQ_0);
+
+  if (!_PSX_CONCAT(PSX_PIO))
+    irq_clear(PIO0_IRQ_0);
+  else
+    irq_clear(PIO1_IRQ_0);
 
   switch (_psx.index) {
   case 1:
@@ -73,8 +78,7 @@ void _impl_psx_handle(void) {
 }
 
 void _impl_psx_init(void) {
-
-  if (_PSX_CONCAT(PSX_PIO)) {
+  if (!_PSX_CONCAT(PSX_PIO)) {
     irq_set_exclusive_handler(PIO0_IRQ_0, _impl_psx_handle);
     irq_set_enabled(PIO0_IRQ_0, true);
   } else {

--- a/arch/pico/impl/psx/psx.pio
+++ b/arch/pico/impl/psx/psx.pio
@@ -73,6 +73,8 @@ poll_att:
     );
 
     // Configure jump
+    gpio_init(att);
+    gpio_set_dir(att, GPIO_IN);
     sm_config_set_jmp_pin(&config, att);
 
     // Configure status register; set RX FIFO to all 1s when empty, 0 otherwise

--- a/common/callbacks.h
+++ b/common/callbacks.h
@@ -41,9 +41,7 @@ WEAK void CALLBACK_OnRGBDrawUSB(USB_OutputReport_t *output);
 // When fallback lighting is active, run this code to perform draws.
 WEAK void CALLBACK_OnRGBDrawFallback(void);
 
-/*** PSX ***/
-// When a PSX input packet is requested
-WEAK void CALLBACK_OnPlaystationInputRequest(PSX_Input_t *input);
+void CALLBACK_OnPlaystationInputRequest(PSX_Input_t *input);
 
 /*** Timer ***/
 // When our timer task can be run

--- a/common/psx.h
+++ b/common/psx.h
@@ -20,7 +20,7 @@ static inline void PSX_Task(void) {
   if (_impl_psx_addressed()) return;
 
   // Poll for new input
-  if (CALLBACK_OnPlaystationInputRequest && _psx.shouldPoll) {
+  if (_psx.shouldPoll) {
     // Capture input
     PSX_Input_t input = {
       .buttons = 0, .rx = 0, .ry = 0, .lx = 0, .ly = 0

--- a/common/psx/game/iidx.c
+++ b/common/psx/game/iidx.c
@@ -1,4 +1,4 @@
-WEAK void CALLBACK_OnPlaystationInputRequest(PSX_Input_t *input) {
+void CALLBACK_OnPlaystationInputRequest(PSX_Input_t *input) {
   const PSX_Button_t button_mapping[] = {
     PSX_Square,
     PSX_L1,


### PR DESCRIPTION
PS2 support had a number of small issues that ultimately culminated in the subsystem not working on PIO. This was also impacted by some kind of SDK update that caused a pin to not be in an expected state. This PR resolves these issues:

- Clear the correct PIO interrupt when handling the PSX input
- Actually setup the interrupt for the correct PIO to begin with
- Call `gpio_init` on the ATT pin and make sure it's an input.
- Remove a couple `WEAK` declarations, which were not being properly pulled over.