### PR TITLE
fix: BSD vs. GNU `sort`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 SHELL = /bin/bash
 
-ALL_BOARDS = $(shell find -s boards -type f -iname 'config.h' -exec dirname {} \; | cut -d'/' -f2- | paste -s -d' ' -)
-ALL_CONTROLLERS = $(shell find -s controllers -type f -iname 'config.h' -exec dirname {} \; | cut -d'/' -f2- | paste -s -d' ' -)
-ALL_LAYOUTS = $(shell find -s layouts -type f -iname 'config.h' -exec dirname {} \; | cut -d'/' -f2- | paste -s -d' ' -)
+ALL_BOARDS = $(shell find boards -type f -iname 'config.h' -exec dirname {} \; | cut -d'/' -f2- | paste -s -d' ' -)
+ALL_CONTROLLERS = $(shell find controllers -type f -iname 'config.h' -exec dirname {} \; | cut -d'/' -f2- | paste -s -d' ' -)
+ALL_LAYOUTS = $(shell find layouts -type f -iname 'config.h' -exec dirname {} \; | cut -d'/' -f2- | paste -s -d' ' -)
 
 .DEFAULT_GOAL := help
 .PHONY: help list-boards list-controllers list-configs %

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 SHELL = /bin/bash
 
-ALL_BOARDS = $(shell find boards -type f -iname 'config.h' -exec dirname {} \; | cut -d'/' -f2- | paste -s -d' ' -)
-ALL_CONTROLLERS = $(shell find controllers -type f -iname 'config.h' -exec dirname {} \; | cut -d'/' -f2- | paste -s -d' ' -)
-ALL_LAYOUTS = $(shell find layouts -type f -iname 'config.h' -exec dirname {} \; | cut -d'/' -f2- | paste -s -d' ' -)
+ALL_BOARDS = $(shell find boards -type f -iname 'config.h' -exec dirname {} \; | cut -d'/' -f2- | sort | paste -s -d' ' -)
+ALL_CONTROLLERS = $(shell find controllers -type f -iname 'config.h' -exec dirname {} \; | cut -d'/' -f2- | sort | paste -s -d' ' -)
+ALL_LAYOUTS = $(shell find layouts -type f -iname 'config.h' -exec dirname {} \; | cut -d'/' -f2- | sort | paste -s -d' ' -)
 
 .DEFAULT_GOAL := help
-.PHONY: help list-boards list-controllers list-configs %
+.PHONY: help list-boards list-controllers list-layouts %
 
 %:
 	@mkdir -p ./build ./obj


### PR DESCRIPTION
BSD `sort` on macOS has the `-s` predicate, which is lacking in GNU `sort`. We can use a separate `sort` pass instead.