### PR TITLE
Fix rotary encoder structs not having initial values set

### DIFF
--- a/common/encoder.h
+++ b/common/encoder.h
@@ -12,7 +12,7 @@ extern _encoder_t _encoder[ENCODERS_ACTIVE];
 // Initialize the encoders
 static inline void Encoder_Init(void) {
 #if (ENCODERS_ACTIVE > 0)
-  for (uint8_t i = ENCODERS_ACTIVE; i < ENCODERS_ACTIVE; i++) {
+  for (uint8_t i = 0; i < ENCODERS_ACTIVE; i++) {
     _encoder[i].state.current = 0,
     _encoder[i].state.pending = 0,
     _encoder[i].state.timeout = 0;


### PR DESCRIPTION
Small one, the Encoder_Init function iterates through each axis via a for loop, but the initial value is the same as the less-than comparison, so no axis will be given its initial values in practice.

This generally doesn't cause a problem because most values are being set to 0 anyway, but it also misses the logical position being set to the midpoint (127,127). Using IIDX as example, the "left stick" inits at (0,0) instead and is locked to (x,0). This increases the likelihood of the device sending rogue stick input to other games if left connected, because it's always in an "up" position.